### PR TITLE
Add :focus style to make navigation work with Tab key

### DIFF
--- a/src/styles/sharedStyles.ts
+++ b/src/styles/sharedStyles.ts
@@ -25,6 +25,7 @@ export const buttonAndLinkStyles = (theme: Theme) => css`
     box-shadow 0.3s ease;
 
   &:hover,
+  &:focus,
   &.active-link {
     background-color: ${theme.colors.lilac};
     border: 2px solid ${theme.colors.lilacShade};


### PR DESCRIPTION
When using the Tab key to navigate through the buttons on the nav bar, the focused button should turn lilac.