### PR TITLE
Fix/testing bug fixes

### DIFF
--- a/__test__/SchedulePage.test.tsx
+++ b/__test__/SchedulePage.test.tsx
@@ -13,7 +13,7 @@ describe('SchedulePage', () => {
 
   test('renders the date paragraph', () => {
     renderWithProviders(<SchedulePage />);
-    const dateParagraph = screen.getByText(/March 3 2025 - GameJam for participating teams/i);
+    const dateParagraph = screen.getByText(/March 3, 2025 - Game Jam for participating teams/i);
     expect(dateParagraph).toBeInTheDocument();
   });
 

--- a/src/components/Table.styled.tsx
+++ b/src/components/Table.styled.tsx
@@ -40,6 +40,10 @@ export const TableContainer = styled.div`
     padding: 0;
   }
 
+  .table-link {
+    color: ${({ theme }) => theme.colors.lilac};
+  }
+
   .favorites-btn {
     ${({ theme }) => buttonAndLinkStyles(theme)}
     padding: 0;

--- a/src/components/Table.tsx
+++ b/src/components/Table.tsx
@@ -1,7 +1,7 @@
-import { useEffect, useState } from "react";
-import { StyledTableHeadingButton, TableContainer } from "./Table.styled";
+import { useEffect, useState } from 'react';
+import { StyledTableHeadingButton, TableContainer } from './Table.styled';
 
-interface TableProps<T extends { id: number }> {
+interface TableProps<T extends { id: number, isFilterable: boolean }> {
   heading?: string;
   headers: string[];
   fieldsToDisplay: (keyof T)[];
@@ -10,7 +10,7 @@ interface TableProps<T extends { id: number }> {
   showFavoritesFilter?: boolean;
 }
 
-export const Table = <T extends { id: number; },>({
+export const Table = <T extends { id: number; isFilterable: boolean; },>({
   heading,
   headers,
   fieldsToDisplay,
@@ -27,14 +27,11 @@ export const Table = <T extends { id: number; },>({
     setFavorites(new Set(storedFavorites));
   }, []);
 
-  useEffect(() => {
-    localStorage.setItem('favorites', JSON.stringify([...favorites]));
-  }, [favorites]);
-
   const toggleFavorite = (id: number) => {
     setFavorites((prev) => {
       const newFavorites = new Set(prev);
       newFavorites.has(id) ? newFavorites.delete(id) : newFavorites.add(id);
+      localStorage.setItem('favorites', JSON.stringify([...newFavorites]))
       return newFavorites;
     });
   };
@@ -65,7 +62,13 @@ export const Table = <T extends { id: number; },>({
   
     return parts.map((part, index) =>
       part.startsWith('http') ? (
-        <a key={index} href={part} target='_blank' rel='noopener noreferrer'>
+        <a
+          key={index}
+          href={part}
+          target='_blank'
+          rel='noopener noreferrer'
+          className='table-link'
+        >
           {part}
         </a>
       ) : (
@@ -98,7 +101,7 @@ export const Table = <T extends { id: number; },>({
         <tbody>
           {filteredData.map((row, rowIndex) => (
             <tr key={rowIndex}>
-              {showFavoritesFilter && (
+              {row.isFilterable ? (showFavoritesFilter && (
                 <td className='checkbox-column'>
                   <input
                     type='checkbox'
@@ -106,7 +109,7 @@ export const Table = <T extends { id: number; },>({
                     onChange={() => toggleFavorite(row.id)}
                   />
                 </td>
-              )}
+              )): <td className='checkbox-column'></td>}
               {fieldsToDisplay.map((field) => {
                 const isLarge = largeFields.includes(field);
                 return (

--- a/src/db.json
+++ b/src/db.json
@@ -126,7 +126,7 @@
       "title": "(Fun)ctionality",
       "description": "How the tools, technologies and techniques from the world of video games can change the way you can design - for joy!",
       "startTime": "10:15",
-      "endTime": "10:45",
+      "endTime": "10:40",
       "location": "Robertson Learning Studio",
       "company": "Scottish Games Network Ltd.",
       "speakers": [
@@ -392,8 +392,8 @@
       "time": "14:40 - 14:50",
       "title": "Go Fish!",
       "description": "Getting over your fear of failure and finding inspiration to create in unlikely places.",
-      "startTime": "14:30",
-      "endTime": "15:00",
+      "startTime": "14:40",
+      "endTime": "14:50",
       "location": "Weston Learning Studio",
       "company": "Hyper Luminal Games",
       "speakers": [

--- a/src/db.json
+++ b/src/db.json
@@ -456,7 +456,7 @@
       "internalColleagues": "For internal employee teams",
       "challengeInternal": "Make learning about what Scottish Widows offers engaging and interactive by using games or gamification to captivate the right generation at the right time.",
       "challengeInternalDescriptor": "On the 3rd March you'll be randomly given one of the following topics:",
-      "internalTopics": " • Investments\n • Budgeting\n • Protection\n • General Insurance\n • Building Your Pension \n • Accessing your Pension",
+      "internalTopics": " • Investments\n • Budgeting and Finance Essentials\n • Life Insurance or Critical Illness\n • Insurance - Pet, Car or Home\n • Building Your Pension \n • Accessing your Pension",
       "externalColleagues": "For external student teams",
       "challengeExternal": "Make a 'Game for Good' to help tackle something that matters to you. Choose from : ",
       "externalTopics": " • Social Justice, Inclusion and Equality\n • Skills and Talent Development\n • Environment and Climate Change",

--- a/src/db.json
+++ b/src/db.json
@@ -452,7 +452,7 @@
       "welcome": "Hello Jammers! 👋",
       "welcomeDescription": "Here are some details of what to expect on the day. We can't wait to see what you create!",
       "challengeTitle": "The Challenge",
-      "challengeDescription": "Your team will create a game based on a theme that will be announced at the start of the game jam. You can use any tools or technology you like.",
+      "challengeDescription": "Your team will create a game based on a theme that will be announced at the start of the Game Jam. You can use any tools or technology you like.",
       "internalColleagues": "For internal employee teams",
       "challengeInternal": "Make learning about what Scottish Widows offers engaging and interactive by using games or gamification to captivate the right generation at the right time.",
       "challengeInternalDescriptor": "On the 3rd March you'll be randomly given one of the following topics:",

--- a/src/db.json
+++ b/src/db.json
@@ -9,7 +9,8 @@
         "Website - https://illustrationtoxic.wixsite.com/illustration-toxic",
         "Instagram - https://www.instagram.com/illustrations.toxic",
         "LinkedIn - https://www.linkedin.com/in/colin-plaice-51b46927b"
-      ]
+      ],
+      "isFilterable": true
     },
     {
       "id": 2,
@@ -18,7 +19,8 @@
       "details": "Studying Experience Design (BDes Hons) at University of Dundee",
       "contact": [
         "Instagram - https://www.instagram.com/naidenovka007"
-      ]
+      ],
+      "isFilterable": true
     },
     {
       "id": 3,
@@ -29,7 +31,8 @@
         "Linktree - https://linktr.ee/GingerGhouls",
         "LinkedIn - https://www.linkedin.com/in/kayley-campbell-7631a4219",
         "Instagram - https://www.instagram.com/gingerghouls"
-      ]
+      ],
+      "isFilterable": true
     },
     {
       "id": 4,
@@ -39,7 +42,8 @@
       "contact": [
         "Instagram - https://www.instagram.com/jewel_a_rae",
         "Email - araejewellery@gmail.com"
-      ]
+      ],
+      "isFilterable": true
     },
     {
       "id": 5,
@@ -48,7 +52,8 @@
       "details": "Researching at Scottish Widows",
       "contact": [
         "LinkedIn - https://www.linkedin.com/in/amyrodgercs"
-      ]
+      ],
+      "isFilterable": true
     },
     {
       "id": 6,
@@ -57,7 +62,8 @@
       "details": "Designing at Scottish Widows",
       "contact": [
         "LinkedIn - https://www.linkedin.com/in/yiiihan"
-      ]
+      ],
+      "isFilterable": true
     },
     {
       "id": 7,
@@ -66,16 +72,17 @@
       "details": "Designing at Scottish Widows",
       "contact": [
         "LinkedIn - https://www.linkedin.com/in/rachel-white-ba4078198"
-      ]
+      ],
+      "isFilterable": true
     }
   ],
   "schedule": [
     {
-      "time": "9:00",
-      "description": "Door open for General Registration - game jam participants and experience ticket.\n\nTea, Coffee and Pastries served in Tatha Canteen, Upper Foyer."
+      "time": "09:00",
+      "description": "Door open for general registration - Game Jam participants and experience ticket.\n\nTea, Coffee and Pastries served in Tatha Canteen, Upper Foyer."
     },
     {
-      "time": "9:30",
+      "time": "09:30",
       "description": "Welcome from Rose, opening remarks from Chira and Maria. Announcements in the Juniper Auditorium."
     },
     {
@@ -96,7 +103,7 @@
     },
     {
       "time": "15:20",
-      "description": "All teams present across two different rooms.\n\nRobertson Learning Studio - Internal Challenge play back.\n\nWeston Learning Studio - external Challenge playback."
+      "description": "All teams present across two different rooms.\n\nRobertson Learning Studio - Internal Challenge playback.\n\nWeston Learning Studio - External Challenge playback."
     },
     {
       "time": "16:45",
@@ -124,7 +131,8 @@
       "company": "Scottish Games Network Ltd.",
       "speakers": [
         "Brian Baglow"
-      ]
+      ],
+      "isFilterable": true
     },
     {
       "id": 2,
@@ -138,7 +146,8 @@
       "company": "Lloyds Banking Group",
       "speakers": [
         "Toby Keech"
-      ]
+      ],
+      "isFilterable": true
     },
     {
       "id": 3,
@@ -152,7 +161,8 @@
       "company": "Opera",
       "speakers": [
         "Russell Kay"
-      ]
+      ],
+      "isFilterable": true
     },
     {
       "id": 4,
@@ -166,7 +176,8 @@
       "company": "",
       "speakers": [
         ""
-      ]
+      ],
+      "isFilterable": true
     },
     {
       "id": 5,
@@ -180,7 +191,8 @@
       "company": "",
       "speakers": [
         ""
-      ]
+      ],
+      "isFilterable": false
     },
     {
       "id": 6,
@@ -195,7 +207,8 @@
       "speakers": [
         "Katy Lynch",
         "Robert Cochran"
-      ]
+      ],
+      "isFilterable": true
     },
     {
       "id": 7,
@@ -209,7 +222,8 @@
       "company": "University of Dundee",
       "speakers": [
         "Fin Tams-Gray"
-      ]
+      ],
+      "isFilterable": true
     },
     {
       "id": 8,
@@ -223,19 +237,21 @@
       "company": "University of Dundee",
       "speakers": [
         "University of Dundee"
-      ]
+      ],
+      "isFilterable": true
     },
     {
       "id": 9,
       "date": "March 4, 2025",
       "time": "15:00 - 15:30",
-      "title": "Break",
+      "title": "BREAK",
       "description": "",
       "startTime": "15:00",
       "endTime": "15:30",
       "location": "Robertson Learning Studio",
       "company": "",
-      "speakers": []
+      "speakers": [],
+      "isFilterable": false
     },
     {
       "id": 10,
@@ -248,26 +264,28 @@
       "location": "Robertson Learning Studio",
       "company": "",
       "speakers": [
-        "Colleagues"
-      ]
+        "Internal Lloyds Colleagues"
+      ],
+      "isFilterable": true
     },
     {
       "id": 11,
       "date": "March 4, 2025",
       "time": "16:45 - 17:00",
-      "title": "Winners announces",
+      "title": "Winners announced",
       "description": "",
       "startTime": "16:45",
       "endTime": "17:00",
       "location": "Robertson Learning Studio",
       "company": "",
-      "speakers": []
+      "speakers": [],
+      "isFilterable": true
     },
     {
       "id": 12,
       "date": "March 4, 2025",
-      "time": "10:15 - 10:45",
-      "title": "The future of Scottish Widows app",
+      "time": "10:15 - 10:40",
+      "title": "The future of the Scottish Widows app",
       "description": "How we're transforming the way the UK saves for the future, levelling up with gamification, and delivering industry changing experiences",
       "startTime": "10:15",
       "endTime": "10:45",
@@ -275,7 +293,8 @@
       "company": "Lloyds Banking Group",
       "speakers": [
         "Andrew Smith and Lilly McNally"
-      ]
+      ],
+      "isFilterable": true
     },
     {
       "id": 13,
@@ -289,7 +308,8 @@
       "company": "Eclectic Synthesis Limited",
       "speakers": [
         "Jake McCullagh"
-      ]
+      ],
+      "isFilterable": true
     },
     {
       "id": 14,
@@ -303,7 +323,8 @@
       "company": "Microsoft",
       "speakers": [
         "Chris Green"
-      ]
+      ],
+      "isFilterable": true
     },
     {
       "id": 15,
@@ -317,7 +338,8 @@
       "company": "Lloyds Banking Group",
       "speakers": [
         "Amy Rodger"
-      ]
+      ],
+      "isFilterable": true
     },
     {
       "id": 16,
@@ -331,7 +353,8 @@
       "company": "",
       "speakers": [
         ""
-      ]
+      ],
+      "isFilterable": false
     },
     {
       "id": 17,
@@ -345,7 +368,8 @@
       "company": "Lloyds Banking Group",
       "speakers": [
         "Dave Cook"
-      ]
+      ],
+      "isFilterable": true
     },
     {
       "id": 18,
@@ -359,7 +383,8 @@
       "company": "Lloyds Banking Group",
       "speakers": [
         "James Macfarlane"
-      ]
+      ],
+      "isFilterable": true
     },
     {
       "id": 19,
@@ -373,13 +398,14 @@
       "company": "Hyper Luminal Games",
       "speakers": [
         "Phoebe Anderson"
-      ]
+      ],
+      "isFilterable": true
     },
     {
       "id": 20,
       "date": "March 4, 2025",
       "time": "15:00 - 15:30",
-      "title": "",
+      "title": "BREAK",
       "description": "",
       "startTime": "15:00",
       "endTime": "15:30",
@@ -387,7 +413,8 @@
       "company": "",
       "speakers": [
         ""
-      ]
+      ],
+      "isFilterable": false
     },
     {
       "id": 21,
@@ -401,13 +428,14 @@
       "company": "",
       "speakers": [
         "University Teams"
-      ]
+      ],
+      "isFilterable": true
     },
     {
       "id": 22,
       "date": "March 4, 2025",
       "time": "16:45 - 17:00",
-      "title": "Winners announces",
+      "title": "Winners announced",
       "description": "",
       "startTime": "16:45",
       "endTime": "17:00",
@@ -415,7 +443,8 @@
       "company": "",
       "speakers": [
         ""
-      ]
+      ],
+      "isFilterable": true
     }
   ],
   "jammers": [

--- a/src/pages/SchedulePage.tsx
+++ b/src/pages/SchedulePage.tsx
@@ -9,7 +9,7 @@ export const SchedulePage = () => {
         Schedule of the Day
       </Heading>
       <CenteredParagraph>
-        March 3 2025 - GameJam for participating teams
+        March 3, 2025 - Game Jam for participating teams
       </CenteredParagraph>
       <CenteredParagraph>
         Find below the running order for March 4, 2025.

--- a/src/pages/TalkAgendaPage.tsx
+++ b/src/pages/TalkAgendaPage.tsx
@@ -28,7 +28,7 @@ export const TalkAgendaPage = () => {
   return (
     <PageContainer>
       <Heading>Talk Agenda</Heading>
-      <CenteredParagraph>Each of the studios only holds 35 people, so they will be first come first serve. If you'd like to attend the talk please make sure you're on time to secure a space.</CenteredParagraph>
+      <CenteredParagraph>Each of the studios holds 35 people, so it will be first come first serve. If you'd like to attend the talk please make sure you're on time to secure a space.</CenteredParagraph>
       <CenteredParagraph>All talks will be held on March 4, 2025.</CenteredParagraph>
       {uniqueLocations.map((location) => (
         <Table

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,6 +5,7 @@ export interface Event {
   title: string;
   description?: string;
   startTime: string;
+  isFilterable: boolean;
   endTime: string;
   location: string;
   speakers: string[];


### PR DESCRIPTION
Fixes:

Schedule page:

- GameJam -> Game Jam
- Comma added after March 3
- 9:00, 9:30 -> 09:00, 09:30
- Doors open for General Registration - game jam participants -> Doors open for general registration - Game Jam participants
- Robertson Learning Studio - Internal Challenge play back -> Robertson Learning Studio - Internal Challenge playback
- Weston Learning Studio - external Challenge playback -> Weston Learning Studio - External Studio playback

Auction page:
- Change colour of link text in table to be lilac, same as that of the link texts in Resources page.

Talk Agenda page:
- Weston Learning Studio:
1. Fix timings (10:15 - 10:45, 14:40 - 14:50)
2. "The future of Scottish Widows app" -> "The future of the Scottish Widows app".
3. Add Break as title for 15:00 - 15:30.

- Robertson Learning Studio:
1. Fix timing (10:15 - 10:45)

- Remove checkboxes for lunch and breaks.
- Save checkbox state between tab navigation.
- "Each of the studios only holds 35 people" -> "Each of the studios holds 35 people, so it will be first come first serve."
- "Colleagues" -> "Internal Lloyds colleagues"
- "Winners announces" -> "Winners announced"